### PR TITLE
6.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+6.1.0
+=======
+
+* Updated Symfony component constraints to `^6.4 || ^7.4` to target Symfony 7.4 LTS.
+* Updated `doctrine/doctrine-bundle` constraint to `^2.11 || ^3.0`, dropping support for the EOL 1.x branch.
+* Updated `becklyn/ddd-doctrine-bridge` to `^3.0` and `becklyn/ddd-core` to `^4.0`, enabling `doctrine/orm ^3.x` and `doctrine/dbal ^4.x` support and removing the abandoned `doctrine/cache` transitive dependency.
+
 6.0.0
 =======
 

--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,16 @@
     "require": {
         "php": ">=8.1",
         "becklyn/ddd-core": "^4.0",
-        "becklyn/ddd-doctrine-bridge": "^3.0.1",
-        "doctrine/doctrine-bundle": "^1.10||^2.0",
-        "simple-bus/message-bus": "^6.0",
-        "simple-bus/symfony-bridge": "^6.0",
-        "symfony/config": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/http-foundation": "^6.4 || ^7.0",
+        "becklyn/ddd-doctrine-bridge": "^3.0",
+        "doctrine/doctrine-bundle": "^2.11 || ^3.0",
+        "symfony/config": "^6.4 || ^7.4",
+        "symfony/dependency-injection": "^6.4 || ^7.4",
+        "symfony/http-foundation": "^6.4 || ^7.4",
         "doctrine/doctrine-migrations-bundle": "^3.0"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.1",
-        "roave/security-advisories": "dev-latest"
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
* Updated Symfony component constraints to `^6.4 || ^7.4` to target Symfony 7.4 LTS.
* Updated `doctrine/doctrine-bundle` constraint to `^2.11 || ^3.0`, dropping support for the EOL 1.x branch.
* Updated `becklyn/ddd-doctrine-bridge` to `^3.0` and `becklyn/ddd-core` to `^4.0`, enabling `doctrine/orm ^3.x` and `doctrine/dbal ^4.x` support and removing the abandoned `doctrine/cache` transitive dependency.