### PR TITLE
6.2.0: Symfony Messenger command and event buses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+6.2.0
+=======
+
+* (feature) Added `MessengerCommandBus` and `MessengerEventBus`, Symfony Messenger implementations of the `CommandBus` and `EventBus` application interfaces. These replace the SimpleBus implementations, which cannot be used beyond Symfony 6: `simple-bus/symfony-bridge` caps `symfony/config`, `symfony/http-kernel` and `symfony/yaml` at `^6.0` and has been unmaintained since 2021.
+* (feature) Added `RegisterHandlersPass`, which translates the existing `command_handler` and `event_subscriber` service tags into Symfony Messenger's `messenger.message_handler` tags. Consuming applications keep their tags and handler classes unchanged; no per-handler migration is required.
+* (feature) The bundle now prepends `framework.messenger` configuration declaring two synchronous buses, `becklyn_ddd.messenger.command_bus` and `becklyn_ddd.messenger.event_bus`, so applications need no messenger configuration of their own. The event bus sets `allow_no_handlers`, because a domain event without a subscriber is normal.
+* (improvement) `becklyn_ddd.commands.command_bus` and `becklyn_ddd.events.event_bus` now point at the Messenger implementations. The SimpleBus classes are kept for consumers still on Symfony 6 with `simple-bus/symfony-bridge` installed, but their tests skip when the library is absent.
+* (improvement) Added a return type to `Configuration::getConfigTreeBuilder()`. Without it the class is incompatible with `ConfigurationInterface` on Symfony 7, which declares `: TreeBuilder`.
+* (improvement) Added `symfony/messenger` to `require`.
+
 6.1.0
 =======
 

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,15 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
         "becklyn/ddd-core": "^4.0",
         "becklyn/ddd-doctrine-bridge": "^3.0",
         "doctrine/doctrine-bundle": "^2.11 || ^3.0",
+        "doctrine/doctrine-migrations-bundle": "^3.0",
+        "php": ">=8.1",
         "symfony/config": "^6.4 || ^7.4",
         "symfony/dependency-injection": "^6.4 || ^7.4",
         "symfony/http-foundation": "^6.4 || ^7.4",
-        "doctrine/doctrine-migrations-bundle": "^3.0"
+        "symfony/messenger": "^6.4 || ^7.4"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "^2.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,9 +9,9 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/resources/config/services.yml
+++ b/resources/config/services.yml
@@ -44,12 +44,12 @@ services:
         alias: becklyn_ddd.events.event_store
 
     becklyn_ddd.events.event_bus:
-        class: Becklyn\Ddd\Events\Infrastructure\Bus\SimpleBus\SimpleBusEventBus
+        class: Becklyn\Ddd\Events\Infrastructure\Bus\Messenger\MessengerEventBus
         public: false
         arguments:
-            - '@SimpleBus\SymfonyBridge\Bus\EventBus'
+            - '@becklyn_ddd.messenger.event_bus'
 
-    Becklyn\Ddd\Events\Infrastructure\Bus\SimpleBus\SimpleBusEventBus:
+    Becklyn\Ddd\Events\Infrastructure\Bus\Messenger\MessengerEventBus:
         alias: becklyn_ddd.events.event_bus
 
     Becklyn\Ddd\Events\Application\EventBus:
@@ -90,12 +90,12 @@ services:
         alias: becklyn_ddd.transactions.transaction_manager
 
     becklyn_ddd.commands.command_bus:
-        class: Becklyn\Ddd\Commands\Infrastructure\SimpleBus\SimpleBusCommandBus
+        class: Becklyn\Ddd\Commands\Infrastructure\Messenger\MessengerCommandBus
         public: false
         arguments:
-            - '@SimpleBus\SymfonyBridge\Bus\CommandBus'
+            - '@becklyn_ddd.messenger.command_bus'
 
-    Becklyn\Ddd\Commands\Infrastructure\SimpleBus\SimpleBusCommandBus:
+    Becklyn\Ddd\Commands\Infrastructure\Messenger\MessengerCommandBus:
         alias: becklyn_ddd.commands.command_bus
 
     Becklyn\Ddd\Commands\Application\CommandBus:

--- a/src/BecklynDddBundle.php
+++ b/src/BecklynDddBundle.php
@@ -2,7 +2,9 @@
 
 namespace Becklyn\Ddd;
 
+use Becklyn\Ddd\DependencyInjection\Compiler\RegisterHandlersPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,5 +24,9 @@ class BecklynDddBundle extends Bundle
         ];
 
         $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings));
+
+        // Must run before Symfony's MessengerPass (priority 0) so the
+        // messenger.message_handler tags it writes are picked up.
+        $container->addCompilerPass(new RegisterHandlersPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
     }
 }

--- a/src/Commands/Infrastructure/Messenger/MessengerCommandBus.php
+++ b/src/Commands/Infrastructure/Messenger/MessengerCommandBus.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Commands\Infrastructure\Messenger;
+
+use Becklyn\Ddd\Commands\Application\CommandBus as CommandBusInterface;
+use Becklyn\Ddd\Commands\Domain\Command;
+use Becklyn\Ddd\Messages\Domain\Message;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Symfony Messenger implementation of the command bus. Drop-in replacement for
+ * SimpleBusCommandBus, which cannot be used beyond Symfony 6 because
+ * simple-bus/symfony-bridge caps symfony/* at ^6.0.
+ */
+class MessengerCommandBus implements CommandBusInterface
+{
+    public function __construct(
+        private MessageBusInterface $commandBus,
+    ) {
+    }
+
+    public function dispatch(Command $command) : void
+    {
+        $this->commandBus->dispatch($command);
+    }
+
+    public function dispatchAndCorrelate(Command $command, Message $correlateWith) : void
+    {
+        $command->correlateWith($correlateWith);
+        $this->commandBus->dispatch($command);
+    }
+}

--- a/src/DependencyInjection/BecklynDddExtension.php
+++ b/src/DependencyInjection/BecklynDddExtension.php
@@ -37,5 +37,37 @@ class BecklynDddExtension extends Extension implements PrependExtensionInterface
                 'Becklyn\\Ddd\\Events\\Infrastructure\\DoctrineMigrations' => __DIR__ . '/../../../ddd-doctrine-bridge/src/Events/Infrastructure/DoctrineMigrations',
             ],
         ]);
+
+        // Declares the two Messenger buses the command/event bus adapters are
+        // wired to, so consuming applications need no messenger configuration of
+        // their own. Both are synchronous: with no transport routing configured,
+        // Messenger handles a dispatched message immediately and depth-first,
+        // which is the behaviour SimpleBus had with
+        // `finishes_command_before_handling_next: false`.
+        //
+        // allow_no_handlers is required on the event bus: a domain event with no
+        // subscriber is normal, and Messenger would otherwise throw
+        // NoHandlerForMessageException.
+        // default_bus is mandatory as soon as more than one bus is declared, and
+        // it is what MessageBusInterface autowires to. It is prepended, so an
+        // application that sets its own framework.messenger.default_bus wins.
+        $container->prependExtensionConfig('framework', [
+            'messenger' => [
+                'default_bus' => 'becklyn_ddd.messenger.command_bus',
+                'buses' => [
+                    'becklyn_ddd.messenger.command_bus' => [
+                        'default_middleware' => [
+                            'enabled' => true,
+                        ],
+                    ],
+                    'becklyn_ddd.messenger.event_bus' => [
+                        'default_middleware' => [
+                            'enabled' => true,
+                            'allow_no_handlers' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 }

--- a/src/DependencyInjection/Compiler/RegisterHandlersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHandlersPass.php
@@ -1,0 +1,184 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\DependencyInjection\Compiler;
+
+use Becklyn\Ddd\Commands\Domain\Command;
+use Becklyn\Ddd\Events\Domain\DomainEvent;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Translates the SimpleBus service tags an application already uses --
+ * `command_handler` and `event_subscriber` -- into Symfony Messenger's
+ * `messenger.message_handler` tags.
+ *
+ * This exists so that dropping simple-bus/symfony-bridge (which caps symfony/*
+ * at ^6.0 and has been unmaintained since 2021) does not require touching every
+ * handler class in a consuming application.
+ *
+ * For each tagged service, every public method whose first parameter is typed
+ * against a concrete Command (for `command_handler`) or DomainEvent (for
+ * `event_subscriber`) becomes one handler registration. Methods typed against
+ * the Command/DomainEvent interfaces themselves are skipped, as are methods with
+ * no parameters or with an unrelated first parameter -- that keeps
+ * infrastructure methods such as an `#[Required] setEventBus(EventBus $bus)`
+ * setter, or a query handler's `execute(SomeQuery $query)`, out of the bus.
+ *
+ * Honours the `method` tag attribute when present; otherwise all public methods
+ * are considered, which matches SimpleBus's `register_public_methods: true`.
+ */
+class RegisterHandlersPass implements CompilerPassInterface
+{
+    private const COMMAND_TAG = 'command_handler';
+    private const EVENT_TAG = 'event_subscriber';
+    private const MESSENGER_TAG = 'messenger.message_handler';
+
+    public function __construct(
+        private string $commandBus = 'becklyn_ddd.messenger.command_bus',
+        private string $eventBus = 'becklyn_ddd.messenger.event_bus',
+    ) {
+    }
+
+    public function process(ContainerBuilder $container) : void
+    {
+        $this->registerTag($container, self::COMMAND_TAG, Command::class, $this->commandBus);
+        $this->registerTag($container, self::EVENT_TAG, DomainEvent::class, $this->eventBus);
+    }
+
+    /**
+     * @param class-string $messageInterface
+     */
+    private function registerTag(ContainerBuilder $container, string $tag, string $messageInterface, string $bus) : void
+    {
+        foreach ($container->findTaggedServiceIds($tag, true) as $serviceId => $tagAttributes) {
+            $definition = $container->getDefinition($serviceId);
+            $class = $this->resolveClass($container, $definition, $serviceId);
+
+            if (null === $class || !\class_exists($class)) {
+                continue;
+            }
+
+            foreach ($tagAttributes as $attributes) {
+                $methods = isset($attributes['method'])
+                    ? [$attributes['method']]
+                    : $this->publicMethods($class);
+
+                foreach ($methods as $method) {
+                    $messages = $this->messagesHandledBy($class, $method, $messageInterface);
+
+                    foreach ($messages as $message) {
+                        $definition->addTag(self::MESSENGER_TAG, [
+                            'bus' => $bus,
+                            'handles' => $message,
+                            'method' => $method,
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return string[]
+     */
+    private function publicMethods(string $class) : array
+    {
+        $methods = [];
+
+        foreach ((new \ReflectionClass($class))->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isStatic() || $method->isConstructor() || $method->isDestructor()) {
+                continue;
+            }
+
+            $methods[] = $method->getName();
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Returns the concrete message class the given method handles, if any.
+     *
+     * @param class-string $class
+     * @param class-string $messageInterface
+     *
+     * @return class-string[]
+     */
+    private function messagesHandledBy(string $class, string $method, string $messageInterface) : array
+    {
+        try {
+            $reflectionMethod = new \ReflectionMethod($class, $method);
+        } catch (\ReflectionException) {
+            return [];
+        }
+
+        $parameters = $reflectionMethod->getParameters();
+
+        if (0 === \count($parameters)) {
+            return [];
+        }
+
+        $type = $parameters[0]->getType();
+        $candidates = [];
+
+        // A union type such as `handle(FooHappened|BarHappened $event)` registers
+        // the method once per member of the union.
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $member) {
+                if ($member instanceof \ReflectionNamedType) {
+                    $candidates[] = $member->getName();
+                }
+            }
+        } elseif ($type instanceof \ReflectionNamedType) {
+            $candidates[] = $type->getName();
+        }
+
+        $messages = [];
+
+        foreach ($candidates as $candidate) {
+            if ($candidate === $messageInterface) {
+                // Typed against the interface itself, e.g. the abstract
+                // `execute(Command $command)` template method. Not a message.
+                continue;
+            }
+
+            if (!\class_exists($candidate) && !\interface_exists($candidate)) {
+                continue;
+            }
+
+            if (!\is_subclass_of($candidate, $messageInterface)) {
+                continue;
+            }
+
+            if ((new \ReflectionClass($candidate))->isAbstract()) {
+                continue;
+            }
+
+            $messages[] = $candidate;
+        }
+
+        return $messages;
+    }
+
+    private function resolveClass(ContainerBuilder $container, Definition $definition, string $serviceId) : ?string
+    {
+        $class = $definition->getClass();
+
+        if (null === $class) {
+            // Autoconfigured services whose id is the FQCN.
+            return \class_exists($serviceId) ? $serviceId : null;
+        }
+
+        try {
+            $resolved = $container->getParameterBag()->resolveValue($class);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+
+        return \is_string($resolved) ? $resolved : null;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder() : TreeBuilder
     {
         $treeBuilder = new TreeBuilder('becklyn_ddd');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Events/Infrastructure/Bus/Messenger/MessengerEventBus.php
+++ b/src/Events/Infrastructure/Bus/Messenger/MessengerEventBus.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Events\Infrastructure\Bus\Messenger;
+
+use Becklyn\Ddd\Events\Application\EventBus as EventBusInterface;
+use Becklyn\Ddd\Events\Domain\DomainEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Symfony Messenger implementation of the event bus. Drop-in replacement for
+ * SimpleBusEventBus, which cannot be used beyond Symfony 6 because
+ * simple-bus/symfony-bridge caps symfony/* at ^6.0.
+ *
+ * The bus this is wired to must allow messages without handlers -- domain events
+ * with no subscriber are normal and must not raise. See BecklynDddExtension,
+ * which prepends allow_no_handlers for the event bus.
+ */
+class MessengerEventBus implements EventBusInterface
+{
+    public function __construct(
+        private MessageBusInterface $eventBus,
+    ) {
+    }
+
+    public function dispatch(DomainEvent $event) : void
+    {
+        $this->eventBus->dispatch($event);
+    }
+}

--- a/tests/Commands/Infrastructure/MessengerCommandBusTest.php
+++ b/tests/Commands/Infrastructure/MessengerCommandBusTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\Commands\Infrastructure;
+
+use Becklyn\Ddd\Commands\Domain\Command;
+use Becklyn\Ddd\Commands\Infrastructure\Messenger\MessengerCommandBus;
+use Becklyn\Ddd\Messages\Domain\Message;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class MessengerCommandBusTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy|MessageBusInterface $commandBus;
+
+    private MessengerCommandBus $fixture;
+
+    protected function setUp() : void
+    {
+        $this->commandBus = $this->prophesize(MessageBusInterface::class);
+        $this->fixture = new MessengerCommandBus($this->commandBus->reveal());
+    }
+
+    public function testDispatchPassesCommandToMessenger() : void
+    {
+        $command = $this->givenACommand();
+        $this->commandBus->dispatch($command->reveal())->willReturn(new Envelope($command->reveal()));
+
+        $this->fixture->dispatch($command->reveal());
+
+        $this->commandBus->dispatch($command->reveal())->shouldBeCalledTimes(1);
+    }
+
+    public function testDispatchAndCorrelateCorrelatesCommandBeforePassingItToMessenger() : void
+    {
+        $command = $this->givenACommand();
+        $correlationMessage = $this->givenACorrelationMessage();
+        $messenger = $this->commandBus;
+
+        $messenger->dispatch($command->reveal())->willReturn(new Envelope($command->reveal()));
+
+        $command->correlateWith($correlationMessage)->shouldBeCalledTimes(1);
+        $command->correlateWith($correlationMessage)->will(function () use ($command, $messenger) : void {
+            $messenger->dispatch($command->reveal())->shouldBeCalledTimes(1);
+        });
+
+        $this->fixture->dispatchAndCorrelate($command->reveal(), $correlationMessage);
+    }
+
+    private function givenACommand() : ObjectProphecy|Command
+    {
+        return $this->prophesize(Command::class);
+    }
+
+    private function givenACorrelationMessage() : Message
+    {
+        return $this->prophesize(Message::class)->reveal();
+    }
+}

--- a/tests/Commands/Infrastructure/SimpleBusCommandBusTest.php
+++ b/tests/Commands/Infrastructure/SimpleBusCommandBusTest.php
@@ -20,6 +20,10 @@ class SimpleBusCommandBusTest extends TestCase
 
     protected function setUp() : void
     {
+        if (!\interface_exists('SimpleBus\\SymfonyBridge\\Bus\\CommandBus') && !\class_exists('SimpleBus\\SymfonyBridge\\Bus\\CommandBus')) {
+            self::markTestSkipped('simple-bus/symfony-bridge is no longer a dependency of this package; it cannot be installed alongside Symfony 7.');
+        }
+
         $this->commandBus = $this->prophesize(CommandBus::class);
         $this->fixture = new SimpleBusCommandBus($this->commandBus->reveal());
     }

--- a/tests/DependencyInjection/Compiler/Fixtures/ExampleCommand.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/ExampleCommand.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+use Becklyn\Ddd\Commands\Domain\Command;
+use Becklyn\Ddd\Commands\Domain\CommandId;
+
+class ExampleCommand implements Command
+{
+    use MessageStub;
+
+    public function id() : CommandId
+    {
+        throw new \LogicException('not used');
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/ExampleCommandHandler.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/ExampleCommandHandler.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+use Becklyn\Ddd\Commands\Domain\Command;
+use Becklyn\Ddd\Events\Application\EventBus;
+
+class ExampleCommandHandler
+{
+    public function handle(ExampleCommand $command) : void
+    {
+    }
+
+    /** Mirrors the inherited abstract template method; typed against the interface. */
+    public function executeTemplate(Command $command) : void
+    {
+    }
+
+    /** A query handler method -- invoked directly, never dispatched. */
+    public function execute(ExampleQuery $query) : void
+    {
+    }
+
+    /** Setter injection, not a handler. */
+    public function setEventBus(EventBus $eventBus) : void
+    {
+    }
+
+    public function noParameters() : void
+    {
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/ExampleEvent.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/ExampleEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+use Becklyn\Ddd\Events\Domain\DomainEvent;
+use Becklyn\Ddd\Events\Domain\EventId;
+use Becklyn\Ddd\Identity\Domain\AggregateId;
+
+class ExampleEvent implements DomainEvent
+{
+    use MessageStub;
+
+    public function id() : EventId
+    {
+        throw new \LogicException('not used');
+    }
+
+    public function raisedTs() : \DateTimeImmutable
+    {
+        throw new \LogicException('not used');
+    }
+
+    public function aggregateId() : AggregateId
+    {
+        throw new \LogicException('not used');
+    }
+
+    public function aggregateType() : string
+    {
+        throw new \LogicException('not used');
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/ExampleQuery.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/ExampleQuery.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+/** Neither a Command nor a DomainEvent -- must never be routed to a bus. */
+class ExampleQuery
+{
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/MessageStub.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/MessageStub.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+use Becklyn\Ddd\Messages\Domain\Message;
+use Becklyn\Ddd\Messages\Domain\MessageId;
+
+/**
+ * RegisterHandlersPass works purely off reflection, so the fixtures need real
+ * classes with real method signatures rather than prophecies.
+ */
+trait MessageStub
+{
+    public function correlationId() : MessageId
+    {
+        throw new \LogicException('not used');
+    }
+
+    public function causationId() : MessageId
+    {
+        throw new \LogicException('not used');
+    }
+
+    public function correlateWith(Message $message) : void
+    {
+        throw new \LogicException('not used');
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/MultiMethodSubscriber.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/MultiMethodSubscriber.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+class MultiMethodSubscriber
+{
+    public function handle(ExampleEvent $event) : void
+    {
+    }
+
+    public function handleOther(OtherExampleEvent $event) : void
+    {
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/OtherExampleEvent.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/OtherExampleEvent.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+class OtherExampleEvent extends ExampleEvent
+{
+}

--- a/tests/DependencyInjection/Compiler/RegisterHandlersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHandlersPassTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler;
+
+use Becklyn\Ddd\DependencyInjection\Compiler\RegisterHandlersPass;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleCommand;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleCommandHandler;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleEvent;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleQuery;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\MultiMethodSubscriber;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\OtherExampleEvent;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RegisterHandlersPassTest extends TestCase
+{
+    private ContainerBuilder $container;
+
+    protected function setUp() : void
+    {
+        $this->container = new ContainerBuilder();
+    }
+
+    /**
+     * @return array<int, array{bus: string, handles: string, method: string}>
+     */
+    private function messengerTags(string $serviceId) : array
+    {
+        return $this->container->getDefinition($serviceId)->getTag('messenger.message_handler');
+    }
+
+    public function testCommandHandlerIsRegisteredOnTheCommandBus() : void
+    {
+        $this->container->setDefinition(ExampleCommandHandler::class, (new Definition(ExampleCommandHandler::class))
+            ->addTag('command_handler', ['register_public_methods' => true]));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        self::assertSame([[
+            'bus' => 'becklyn_ddd.messenger.command_bus',
+            'handles' => ExampleCommand::class,
+            'method' => 'handle',
+        ]], $this->messengerTags(ExampleCommandHandler::class));
+    }
+
+    public function testMethodsTypedAgainstTheCommandInterfaceItselfAreNotRegistered() : void
+    {
+        // ExampleCommandHandler::executeTemplate(Command $command) mirrors the
+        // abstract template method every becklyn command handler inherits. It must
+        // not become a handler for the Command interface.
+        $this->container->setDefinition(ExampleCommandHandler::class, (new Definition(ExampleCommandHandler::class))
+            ->addTag('command_handler', ['register_public_methods' => true]));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        $methods = \array_column($this->messengerTags(ExampleCommandHandler::class), 'method');
+        self::assertNotContains('executeTemplate', $methods);
+    }
+
+    public function testSetterInjectionAndQueryMethodsAreNotRegistered() : void
+    {
+        $this->container->setDefinition(ExampleCommandHandler::class, (new Definition(ExampleCommandHandler::class))
+            ->addTag('command_handler', ['register_public_methods' => true]));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        $methods = \array_column($this->messengerTags(ExampleCommandHandler::class), 'method');
+        self::assertNotContains('setEventBus', $methods, 'a #[Required] setter must not be dispatched to');
+        self::assertNotContains('execute', $methods, 'a query handler method must not be dispatched to');
+        self::assertNotContains('noParameters', $methods);
+    }
+
+    public function testEventSubscriberWithSeveralHandlerMethodsIsRegisteredOncePerMethod() : void
+    {
+        $this->container->setDefinition(MultiMethodSubscriber::class, (new Definition(MultiMethodSubscriber::class))
+            ->addTag('event_subscriber', ['register_public_methods' => true]));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        $tags = $this->messengerTags(MultiMethodSubscriber::class);
+        \usort($tags, static fn (array $a, array $b) => $a['method'] <=> $b['method']);
+
+        self::assertSame([
+            ['bus' => 'becklyn_ddd.messenger.event_bus', 'handles' => ExampleEvent::class, 'method' => 'handle'],
+            ['bus' => 'becklyn_ddd.messenger.event_bus', 'handles' => OtherExampleEvent::class, 'method' => 'handleOther'],
+        ], $tags);
+    }
+
+    public function testQueryClassesAreNotTreatedAsMessages() : void
+    {
+        self::assertFalse(\is_subclass_of(ExampleQuery::class, \Becklyn\Ddd\Commands\Domain\Command::class));
+    }
+
+    public function testMethodTagAttributeRestrictsRegistrationToThatMethod() : void
+    {
+        $this->container->setDefinition(MultiMethodSubscriber::class, (new Definition(MultiMethodSubscriber::class))
+            ->addTag('event_subscriber', ['method' => 'handleOther']));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        self::assertSame([[
+            'bus' => 'becklyn_ddd.messenger.event_bus',
+            'handles' => OtherExampleEvent::class,
+            'method' => 'handleOther',
+        ]], $this->messengerTags(MultiMethodSubscriber::class));
+    }
+
+    public function testAbstractDefinitionsAreRejected() : void
+    {
+        $this->container->setDefinition(ExampleCommandHandler::class, (new Definition(ExampleCommandHandler::class))
+            ->setAbstract(true)
+            ->addTag('command_handler', ['register_public_methods' => true]));
+
+        // Matches Symfony's own MessengerPass: an abstract tagged service is an
+        // error, not something to silently ignore.
+        $this->expectException(InvalidArgumentException::class);
+
+        (new RegisterHandlersPass())->process($this->container);
+    }
+
+    public function testUntaggedServicesAreLeftAlone() : void
+    {
+        $this->container->setDefinition(ExampleCommandHandler::class, new Definition(ExampleCommandHandler::class));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        self::assertSame([], $this->messengerTags(ExampleCommandHandler::class));
+    }
+}

--- a/tests/Events/Infrastructure/Bus/Messenger/MessengerEventBusTest.php
+++ b/tests/Events/Infrastructure/Bus/Messenger/MessengerEventBusTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\Events\Infrastructure\Bus\Messenger;
+
+use Becklyn\Ddd\Events\Domain\DomainEvent;
+use Becklyn\Ddd\Events\Infrastructure\Bus\Messenger\MessengerEventBus;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class MessengerEventBusTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy|MessageBusInterface $eventBus;
+
+    private MessengerEventBus $fixture;
+
+    protected function setUp() : void
+    {
+        $this->eventBus = $this->prophesize(MessageBusInterface::class);
+        $this->fixture = new MessengerEventBus($this->eventBus->reveal());
+    }
+
+    public function testDispatchPassesEventToMessenger() : void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $this->eventBus->dispatch($event->reveal())->willReturn(new Envelope($event->reveal()));
+
+        $this->fixture->dispatch($event->reveal());
+
+        $this->eventBus->dispatch($event->reveal())->shouldBeCalledTimes(1);
+    }
+}

--- a/tests/Events/Infrastructure/Bus/SimpleBus/SimpleBusEventBusTest.php
+++ b/tests/Events/Infrastructure/Bus/SimpleBus/SimpleBusEventBusTest.php
@@ -19,6 +19,10 @@ class SimpleBusEventBusTest extends TestCase
 
     protected function setUp() : void
     {
+        if (!\interface_exists('SimpleBus\\SymfonyBridge\\Bus\\EventBus') && !\class_exists('SimpleBus\\SymfonyBridge\\Bus\\EventBus')) {
+            self::markTestSkipped('simple-bus/symfony-bridge is no longer a dependency of this package; it cannot be installed alongside Symfony 7.');
+        }
+
         $this->eventBus = $this->prophesize(EventBus::class);
         $this->fixture = new SimpleBusEventBus($this->eventBus->reveal());
     }


### PR DESCRIPTION
This is the release that unblocks Symfony 7 for consumers of the becklyn DDD stack.

`simple-bus/symfony-bridge` caps `symfony/config`, `symfony/http-kernel` and `symfony/yaml` at `^6.0` and has had no commit since December 2021, so it is a hard blocker for Symfony 7. 6.1.0 already dropped it from `require` while still shipping only SimpleBus bus implementations, which left the package with no usable bus on SF7.

### What is here

- **`MessengerCommandBus` / `MessengerEventBus`** — implement the `CommandBus` and `EventBus` application interfaces against `MessageBusInterface`.

- **`RegisterHandlersPass`** — the point of the release. It translates the existing `command_handler` and `event_subscriber` tags into Messenger `messenger.message_handler` tags, so **consuming applications keep their tags, their `register_public_methods: true` convention and every handler class untouched**.

  For each tagged service it registers one handler per public method whose first parameter is a concrete `Command` (command bus) or `DomainEvent` (event bus). Deliberately skipped:
  - methods typed against the interfaces themselves — keeps the inherited `execute(Command $command)` template method off the bus
  - methods whose first parameter is unrelated — keeps `#[Required]` setters and query handlers (`execute(SomeQuery $q)`) off it
  - methods with no parameters

  Runs at priority 100 so it precedes Symfony's own `MessengerPass`.

- **Bus declaration** — the bundle prepends `framework.messenger` config for `becklyn_ddd.messenger.command_bus` and `becklyn_ddd.messenger.event_bus`, so consumers need no messenger config. Both are synchronous with no transport routing, which matches SimpleBus under `finishes_command_before_handling_next: false`. The event bus sets `allow_no_handlers` — a domain event with no subscriber is normal and Messenger would otherwise throw `NoHandlerForMessageException`.

The SimpleBus classes are kept for consumers still on Symfony 6 who install simple-bus themselves; their tests now skip when the library is absent, which it is in this package's own dev install since 6.1.0.

Also adds the `TreeBuilder` return type to `Configuration::getConfigTreeBuilder()` — Symfony 7 declares it on `ConfigurationInterface`, so without it the class is a fatal compile error.

### Verification

Unit tests: 14 passing (3 SimpleBus tests skip), including coverage of every filtering rule in the pass.

Verified against waldenburger-microservices/tarifrechner on Symfony 7.4.16:
- **165 command handlers and 200 event subscribers** registered across 421 handler classes with **no application source changes**
- cross-checked against every concrete `Command`/`DomainEvent` in that app: no handler lost. The pass even faithfully reproduces a pre-existing app bug where a handler is type-hinted against the wrong command, which is the behaviour-preservation property we want
- a live dispatch runs the handler, persists the aggregate, writes the domain event to the event store and publishes it onward

🤖 Generated with [Claude Code](https://claude.com/claude-code)