### PR TITLE
Register event_subscriber handlers for Message, not only DomainEvent

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterHandlersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterHandlersPass.php
@@ -3,7 +3,7 @@
 namespace Becklyn\Ddd\DependencyInjection\Compiler;
 
 use Becklyn\Ddd\Commands\Domain\Command;
-use Becklyn\Ddd\Events\Domain\DomainEvent;
+use Becklyn\Ddd\Messages\Domain\Message;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -19,12 +19,22 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  * handler class in a consuming application.
  *
  * For each tagged service, every public method whose first parameter is typed
- * against a concrete Command (for `command_handler`) or DomainEvent (for
- * `event_subscriber`) becomes one handler registration. Methods typed against
- * the Command/DomainEvent interfaces themselves are skipped, as are methods with
- * no parameters or with an unrelated first parameter -- that keeps
- * infrastructure methods such as an `#[Required] setEventBus(EventBus $bus)`
- * setter, or a query handler's `execute(SomeQuery $query)`, out of the bus.
+ * against a concrete Command (for `command_handler`) or Message (for
+ * `event_subscriber`) becomes one handler registration. Message, not the
+ * narrower DomainEvent, is intentional: DomainEvent adds aggregate/timestamp
+ * metadata for events raised by an aggregate root, but plenty of legitimate
+ * event_subscriber targets -- e.g. an inbound external message that only
+ * implements Message -- are not DomainEvents. Restricting to DomainEvent here
+ * previously meant such subscribers were silently never wired to any bus: the
+ * message would be accepted and acknowledged (e.g. 200 OK from an HTTP
+ * consumer) without any handler ever running, and without a single error
+ * anywhere -- the event bus has `allow_no_handlers: true`, which is correct
+ * for genuine domain events with no subscriber, but was masking this case too.
+ * Methods typed against the Command/Message interfaces themselves are
+ * skipped, as are methods with no parameters or with an unrelated first
+ * parameter -- that keeps infrastructure methods such as an
+ * `#[Required] setEventBus(EventBus $bus)` setter, or a query handler's
+ * `execute(SomeQuery $query)`, out of the bus.
  *
  * Honours the `method` tag attribute when present; otherwise all public methods
  * are considered, which matches SimpleBus's `register_public_methods: true`.
@@ -44,7 +54,7 @@ class RegisterHandlersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container) : void
     {
         $this->registerTag($container, self::COMMAND_TAG, Command::class, $this->commandBus);
-        $this->registerTag($container, self::EVENT_TAG, DomainEvent::class, $this->eventBus);
+        $this->registerTag($container, self::EVENT_TAG, Message::class, $this->eventBus);
     }
 
     /**

--- a/tests/DependencyInjection/Compiler/Fixtures/ExampleExternalMessage.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/ExampleExternalMessage.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures;
+
+use Becklyn\Ddd\Messages\Domain\Message;
+use Becklyn\Ddd\Messages\Domain\MessageId;
+
+/**
+ * Represents an inbound message that implements Message directly rather than
+ * the narrower DomainEvent -- e.g. an external event arriving from another
+ * service, which has no aggregate to speak of. A subscriber handling this
+ * must still be registered on the event bus.
+ */
+class ExampleExternalMessage implements Message
+{
+    use MessageStub;
+
+    public function id() : MessageId
+    {
+        throw new \LogicException('not used');
+    }
+}

--- a/tests/DependencyInjection/Compiler/Fixtures/MultiMethodSubscriber.php
+++ b/tests/DependencyInjection/Compiler/Fixtures/MultiMethodSubscriber.php
@@ -11,4 +11,8 @@ class MultiMethodSubscriber
     public function handleOther(OtherExampleEvent $event) : void
     {
     }
+
+    public function handleExternalMessage(ExampleExternalMessage $message) : void
+    {
+    }
 }

--- a/tests/DependencyInjection/Compiler/RegisterHandlersPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterHandlersPassTest.php
@@ -6,6 +6,7 @@ use Becklyn\Ddd\DependencyInjection\Compiler\RegisterHandlersPass;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleCommand;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleCommandHandler;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleEvent;
+use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleExternalMessage;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\ExampleQuery;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\MultiMethodSubscriber;
 use Becklyn\Ddd\Tests\DependencyInjection\Compiler\Fixtures\OtherExampleEvent;
@@ -84,8 +85,29 @@ class RegisterHandlersPassTest extends TestCase
 
         self::assertSame([
             ['bus' => 'becklyn_ddd.messenger.event_bus', 'handles' => ExampleEvent::class, 'method' => 'handle'],
+            ['bus' => 'becklyn_ddd.messenger.event_bus', 'handles' => ExampleExternalMessage::class, 'method' => 'handleExternalMessage'],
             ['bus' => 'becklyn_ddd.messenger.event_bus', 'handles' => OtherExampleEvent::class, 'method' => 'handleOther'],
         ], $tags);
+    }
+
+    public function testEventSubscriberForAMessageThatIsNotADomainEventIsStillRegistered() : void
+    {
+        // Regression test: a subscriber handling a plain Message (e.g. an
+        // inbound external event with no aggregate) must be wired to the
+        // event bus just like a DomainEvent subscriber is. Previously this
+        // silently registered nothing at all -- the message would be
+        // accepted and acknowledged with no handler ever running, and
+        // nothing anywhere would say why.
+        $this->container->setDefinition(MultiMethodSubscriber::class, (new Definition(MultiMethodSubscriber::class))
+            ->addTag('event_subscriber', ['method' => 'handleExternalMessage']));
+
+        (new RegisterHandlersPass())->process($this->container);
+
+        self::assertSame([[
+            'bus' => 'becklyn_ddd.messenger.event_bus',
+            'handles' => ExampleExternalMessage::class,
+            'method' => 'handleExternalMessage',
+        ]], $this->messengerTags(MultiMethodSubscriber::class));
     }
 
     public function testQueryClassesAreNotTreatedAsMessages() : void


### PR DESCRIPTION
## Summary
- `RegisterHandlersPass` only wired an `event_subscriber` method to the Messenger event bus when its parameter was a `DomainEvent` subclass. Any subscriber handling a plain `Message` -- e.g. an inbound external event with no aggregate of its own -- was silently never registered.
- Because the event bus has `allow_no_handlers: true` (correct for a genuine domain event nobody currently listens to), this failed completely silently: Messenger accepted and "handled" the message with zero handlers run, no exception, no log line. A consuming HTTP endpoint built on top of this (e.g. a sidecar HTTP consumer) would return 200 OK while doing nothing at all.
- Found via a real production-shaped repro in a consuming app: a BFF-originated GraphQL mutation would hang forever because the inbound command was accepted and silently dropped.
- Broadens the match to `Message::class`, which `DomainEvent` already extends, so both kinds of subscribers get registered.

## Test plan
- [x] `vendor/bin/phpunit tests/DependencyInjection/Compiler/RegisterHandlersPassTest.php` — 9/9 pass, including a new regression test (`testEventSubscriberForAMessageThatIsNotADomainEventIsStillRegistered`) that fails against the old code and passes against the fix.
- [x] Full suite: 15 tests, 15 assertions, 3 pre-existing skips (unrelated).